### PR TITLE
新增 init 生命周期，支持用户在外层定制化 markdown 的插件和行为

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -3,6 +3,7 @@ import { createMarkdownRenderer } from './markdown/markdown';
 function createMarkdown(options) {
   const { markdown = {} } = options;
   const md = createMarkdownRenderer(markdown);
+  if (options.markdown && options.markdown.init) options.markdown.init({ md })
 
   return (source, file) => {
     const { transforms = {} } = options;


### PR DESCRIPTION
新增 init 生命周期，支持在外层定制化 markdown 的插件和行为，例如在 `init()` 生命周期中新增/修改/删除 `markdown-it` 更多的插件能力。

配置路径和签名 `markdown.init({ md: MarkdownIt })`。

和 `transforms.before` 不同的是 `before` 每个文件编译中都会运行，而 `init` 仅在 `markdown-it` 初始化的阶段调用一次。